### PR TITLE
When configuring 'git_versioninfo.cpp', do not always overwrite the file we compile; generate a temporary file, and only overwrite if it is has changed

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -5,6 +5,7 @@
 find_package(Git)
 configure_file(GitInfo.cmake.in GitInfo.cmake @ONLY)
 add_custom_target(gen-gitinfo
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/git_versioninfo.cpp
   COMMAND ${CMAKE_COMMAND} -DGIT_FOUND=${GIT_FOUND} -P GitInfo.cmake)
 
 #-----------------------------------------------------------------------------#

--- a/src/base/GitInfo.cmake.in
+++ b/src/base/GitInfo.cmake.in
@@ -31,5 +31,28 @@ if(GIT_FOUND)
   endif()
 endif()
 
+#
+# We only want to update 'git_versioninfo.cpp' if the git info has changed
+#
+
+# Temporary file name
+set(TEMP_GIT_INFO git_versioninfo.cpp.curr)
+
+# Target file name
+set(FINAL_GIT_INFO git_versioninfo.cpp)
+
+# Configure our tempory file
 configure_file(
-  @CMAKE_CURRENT_SOURCE_DIR@/git_versioninfo.cpp.in git_versioninfo.cpp)
+  @CMAKE_CURRENT_SOURCE_DIR@/git_versioninfo.cpp.in ${TEMP_GIT_INFO})
+
+# Compare the target file against the temporary file name
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E compare_files ${TEMP_GIT_INFO} ${FINAL_GIT_INFO}
+  RESULT_VARIABLE GIT_UNCHANGED)
+
+# If the files are not equal (or ${FINAL_GIT_INFO} does not exist!), then we
+# overwrite the target file
+if(NOT GIT_UNCHANGED EQUAL 0)
+  configure_file(${TEMP_GIT_INFO} ${FINAL_GIT_INFO} COPYONLY)
+endif()
+


### PR DESCRIPTION
Attempt to ensure we don't have unnecessary compiles.

We want to see:
```
[4/513] cd /home/avj/clones/CVC4/git_info/bui...2/bin/cmake -DGIT_FOUND=TRUE -P GitInfo.cmake
Files "git_versioninfo.cpp.curr" to "git_versioninfo.cpp" are different.
```

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>