### PR TITLE
Splitting on sequences equality

### DIFF
--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -419,6 +419,8 @@ const char* toString(InferenceId i)
       return "STRINGS_ARRAY_NTH_TERM_FROM_UPDATE";
     case InferenceId::STRINGS_ARRAY_UPDATE_BOUND:
       return "STRINGS_ARRAY_UPDATE_BOUND";
+    case InferenceId::STRINGS_ARRAY_EQ_SPLIT:
+	  return "STRINGS_ARRAY_EQ_SPLIT";
     case InferenceId::STRINGS_ARRAY_NTH_UPDATE_WITH_UNIT:
       return "STRINGS_ARRAY_NTH_UPDATE_WITH_UNIT";
     case InferenceId::STRINGS_ARRAY_NTH_REV: return "STRINGS_ARRAY_NTH_REV";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -700,6 +700,8 @@ enum class InferenceId
   STRINGS_ARRAY_NTH_TERM_FROM_UPDATE,
   // reasoning about whether an update changes a term or not
   STRINGS_ARRAY_UPDATE_BOUND,
+  // splitting about equality of sequences
+  STRINGS_ARRAY_EQ_SPLIT,
   // nth over update when updated with an unit term
   STRINGS_ARRAY_NTH_UPDATE_WITH_UNIT,
   // nth over reverse

--- a/src/theory/strings/array_core_solver.cpp
+++ b/src/theory/strings/array_core_solver.cpp
@@ -81,6 +81,19 @@ void ArrayCoreSolver::checkNth(const std::vector<Node>& nthTerms)
       sendInference(exp, lem, InferenceId::STRINGS_ARRAY_NTH_EXTRACT);
     }
   }
+  for (uint i=0; i < nthTerms.size(); i++) {
+    for (uint j=i+1; j < nthTerms.size(); j++) {
+       std::vector<Node> exp;
+       Node x = nthTerms[i][0];
+       Node y = nthTerms[j][0];
+       Node n = nthTerms[i][1];
+       Node m = nthTerms[j][1];
+       if (d_state.areEqual(n, m)) {
+         Node lem = nm->mkNode(OR, nm->mkNode(EQUAL, x, y), nm->mkNode(DISTINCT, x, y));
+           sendInference(exp, lem, InferenceId::STRINGS_ARRAY_EQ_SPLIT);
+       }
+    }
+  }
 }
 
 void ArrayCoreSolver::checkUpdate(const std::vector<Node>& updateTerms)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1101,6 +1101,7 @@ set(regress_0_tests
   regress0/sep/skolem_emp.smt2
   regress0/sep/trees-1.smt2
   regress0/sep/wand-crash.smt2
+  regress0/seq/err1.smt2
   regress0/seq/intseq.smt2
   regress0/seq/intseq_dt.smt2
   regress0/seq/issue4370-bool-terms.smt2

--- a/test/regress/regress0/seq/err1.smt2
+++ b/test/regress/regress0/seq/err1.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --strings-exp --seq-array=lazy
+; EXPECT: unsat
+(set-logic ALL)
+(declare-sort E 0)
+(declare-fun a () (Seq E))
+(declare-fun a_ () (Seq E))
+(declare-fun _3 () (Seq E))
+(declare-fun _4 () (Seq E))
+(declare-fun _39 () E)
+(declare-fun e () E)
+(assert (= (str.update _3 0 (seq.unit _39)) (str.update a 1 (seq.unit e))))
+(assert (= a (str.update a 1 (seq.unit (seq.nth (str.update a 1 (seq.unit e)) 2)))))
+(assert (= (str.update (str.update _3 0 (seq.unit e)) 0 (seq.unit _39)) (str.update _4 1 (seq.unit e))))
+(assert (= e (seq.nth (str.update _4 1 (seq.unit e)) 2)))
+(assert (distinct a (str.update _4 1 (seq.unit (seq.nth (str.update _3 0 (seq.unit e)) 1)))))
+(check-sat)


### PR DESCRIPTION
adding the following rule:
```
nth(x,i),nth(y,i) \in ter(S)            x=y \notin S, x!=y\notin S
—————————————————————————————
x = y || x != y
```

The new smtlib file that causes `sat` instead of `unsat` result is included as a regression and passes.
One regression fails with proof checking (but passes without): 
`regress0/seq/array/update-word-eq.smt2`, but it does not fail on the original `fixNthUpdate` branch.